### PR TITLE
add openapi.generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# kotlin-realworld-api
+# Documentation for realworld-api
+
+<a name="documentation-for-api-endpoints"></a>
+## Documentation for API Endpoints
+
+All URIs are relative to *http://localhost*
+
+| Class | Method | HTTP request | Description |
+|------------ | ------------- | ------------- | -------------|
+| *DefaultApi* | [**getSampleMessage**](Apis/DefaultApi.md#getsamplemessage) | **GET** /sample | Returns a sample message |
+
+
+<a name="documentation-for-models"></a>
+## Documentation for Models
+
+
+
+<a name="documentation-for-authorization"></a>
+## Documentation for Authorization
+
+All endpoints do not require authorization.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,11 @@
+import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
+
 plugins {
     kotlin("jvm") version "2.0.0"
     kotlin("plugin.spring") version "2.0.0"
     id("org.springframework.boot") version "3.3.0"
     id("io.spring.dependency-management") version "1.1.5"
+    id("org.openapi.generator") version "7.6.0"
 }
 
 group = "com.example"
@@ -19,16 +22,57 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+    implementation("org.springdoc:springdoc-openapi-ui:1.8.0")
+    implementation("io.swagger.core.v3:swagger-annotations:2.2.22")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.3.0")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.register<GenerateTask>("buildMarkdownApiDoc") {
+    generatorName.set("markdown")
+    inputSpec.set("$rootDir/src/main/resources/openapi.yaml")
+    outputDir.set("$buildDir/api-doc")
+    doLast {
+        val readmeFile = file("$rootDir/README.md")
+        val generatedDoc = file("$buildDir/api-doc/README.md")
+        if (generatedDoc.exists()) {
+            readmeFile.writeText(generatedDoc.readText())
+        } else {
+            throw GradleException("Generated Markdown API doc not found: $generatedDoc")
+        }
+    }
+}
+
+openApiGenerate {
+    generatorName.set("kotlin-spring")
+    inputSpec.set("$rootDir/src/main/resources/openapi.yaml")
+    outputDir.set("$buildDir/spring")
+    apiPackage.set("com.example.todoapi.controller")
+    modelPackage.set("com.example.todoapi.model")
+    configOptions.set(
+        mapOf(
+            "interfaceOnly" to "true",
+            "useSpringBoot3" to "true"
+        )
+    )
+}
+
+sourceSets {
+    main {
+        java {
+            srcDirs("$buildDir/spring/src/main/kotlin")
+        }
+    }
 }
 
 kotlin {

--- a/src/main/kotlin/com/example/kotlin_realworld_api/controller/SampleController.kt
+++ b/src/main/kotlin/com/example/kotlin_realworld_api/controller/SampleController.kt
@@ -1,0 +1,13 @@
+package com.example.kotlin_realworld_api.controller
+
+import com.example.todoapi.controller.SampleApi
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class SampleController : SampleApi {
+    override fun getSampleMessage(): ResponseEntity<String> {
+        return ResponseEntity("Hello, kyoto_kanko!", HttpStatus.OK)
+    }
+}

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.1.0
+info:
+  title: realworld-api
+  description: Implementing the RealWorld API in Kotlin
+  version: 1.0.0
+paths:
+  /sample:
+    get:
+      summary: Returns a sample message
+      operationId: getSampleMessage
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                type: string


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new `/sample` API endpoint that returns a sample message.
  - Introduced OpenAPI documentation generation, including a new `openapi.yaml` specification file.
  
- **Documentation**
  - Updated README with sections for API endpoints, models, and authorization details.

- **Chores**
  - Updated build configuration to include plugins and dependencies for OpenAPI documentation and code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->